### PR TITLE
build-info: update Gluon to 2024-02-06

### DIFF
--- a/.github/build-info.json
+++ b/.github/build-info.json
@@ -2,7 +2,7 @@
     "gluon": {
         "repository": "freifunk-gluon/gluon",
         "branch": "v2021.1.x",
-        "commit": "f1f7f616aa0623328ae322c6cb001a0166573187"
+        "commit": "3181e496f4b79234beec1a90ed9fca206a6708c7"
     },
     "container": {
         "image": "ghcr.io/herbetom/gluon-build",


### PR DESCRIPTION
Update Gluon from f1f7f616 to 3181e496.

~~~
3181e496 Merge pull request #3182 from kpanic23/v2021.1.x
72f983dc modules: update packages
967f0642 Merge pull request #3176 from T-X/v2021.1.x-bridge-mcast-uptime-fix
982c0cf6 kernel: bridge: mcast: fix disabled snooping after long uptime
36b8adb6 Merge pull request #3079 from T-X/v2021.1.x-small-updates+backports
d5aab831 scripts/modules.sh: move site feeds to the front of the module list
60011ecb modules: move Gluon packages to front of module list
11c1b29a modules: update OpenWrt routing packages
70fa3b70 modules: update OpenWrt packages
660bdfa7 modules: update OpenWrt base
63ec4d51 Merge pull request #3082 from blocktrron/v2021.1.x-downgrade-runner-version
f4e1b75d docs: pin sphinx version
b0719753 docs: GH use `requirements.txt`
1a5e0c1c docs: pin theme version
dfe0c5dd ci: pin runner version to Ubuntu 20.04
~~~

Signed-off-by: GitHub Actions <info@freifunk-rhein-neckar.de>